### PR TITLE
Fix widget tooltip display issue

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -106,6 +106,27 @@ class _MyHomePageState extends State<MyHomePage> {
               message: Text('asdf', style: Theme.of(context).textTheme.titleLarge?.copyWith(color: Colors.white)),
               child: const Text('tap outside'),
             ),
+            WidgetTooltip(
+              triggerMode: WidgetTooltipTriggerMode.tap,
+              dismissMode: WidgetTooltipDismissMode.tapAnyWhere,
+              messagePadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              messageDecoration: BoxDecoration(
+                color: Colors.blue,
+                borderRadius: BorderRadius.circular(8),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withOpacity(0.2),
+                    blurRadius: 8,
+                    offset: const Offset(0, 2),
+                  ),
+                ],
+              ),
+              message: Text(
+                'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.',
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: Colors.white),
+              ),
+              child: const Text('Long text test'),
+            ),
           ],
         ),
       ),

--- a/lib/src/widget_tooltip.dart
+++ b/lib/src/widget_tooltip.dart
@@ -245,13 +245,21 @@ class _WidgetTooltipState extends State<WidgetTooltip>
   void show() {
     if (_animationController.isAnimating) return;
 
+    final resolvedPadding = widget.padding.resolve(TextDirection.ltr);
+    final horizontalPadding = resolvedPadding.left + resolvedPadding.right;
+
     final Widget messageBox = Material(
       type: MaterialType.transparency,
-      child: Container(
-        key: messageBoxKey,
-        padding: widget.messagePadding,
-        decoration: widget.messageDecoration,
-        child: widget.message,
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          maxWidth: MediaQuery.of(context).size.width - horizontalPadding,
+        ),
+        child: Container(
+          key: messageBoxKey,
+          padding: widget.messagePadding,
+          decoration: widget.messageDecoration,
+          child: widget.message,
+        ),
       ),
     );
 


### PR DESCRIPTION
- Add ConstrainedBox to messageBox to limit maximum width
- Maximum width is set to screen width minus horizontal padding
- This ensures right padding is visible even with long text
- Add test case with long Lorem Ipsum text to example app