### PR TITLE
fix: respect autoFlip property in layout calculation

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -127,10 +127,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.16.0"
   path:
     dependency: transitive
     description:
@@ -188,10 +188,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.6"
   vector_math:
     dependency: transitive
     description:

--- a/lib/src/widget_tooltip.dart
+++ b/lib/src/widget_tooltip.dart
@@ -424,29 +424,42 @@ class _WidgetTooltipState extends State<WidgetTooltip>
       targetPosition.dy + targetSize.height / 2,
     );
 
-    // Direction flags — v1.1.4 logic: direction always takes precedence
+    // Direction flags — direction always takes precedence.
+    // When autoFlip is false and no direction is set, use sensible defaults
+    // (bottom for vertical, right for horizontal) instead of screen-center logic.
+    final screenWidth = MediaQuery.of(context).size.width;
+    final screenHeight = MediaQuery.of(context).size.height;
+
     final bool isLeft = switch (widget.direction) {
       WidgetTooltipDirection.left => false,
       WidgetTooltipDirection.right => true,
-      _ => targetCenter.dx <= MediaQuery.of(context).size.width / 2,
+      _ => widget.autoFlip
+          ? targetCenter.dx <= screenWidth / 2
+          : true, // default: tooltip to the right (isLeft means target is on left side)
     };
 
     final bool isRight = switch (widget.direction) {
       WidgetTooltipDirection.left => true,
       WidgetTooltipDirection.right => false,
-      _ => targetCenter.dx > MediaQuery.of(context).size.width / 2,
+      _ => widget.autoFlip
+          ? targetCenter.dx > screenWidth / 2
+          : false,
     };
 
     final bool isBottom = switch (widget.direction) {
       WidgetTooltipDirection.top => true,
       WidgetTooltipDirection.bottom => false,
-      _ => targetCenter.dy > MediaQuery.of(context).size.height / 2,
+      _ => widget.autoFlip
+          ? targetCenter.dy > screenHeight / 2
+          : false,
     };
 
     final bool isTop = switch (widget.direction) {
       WidgetTooltipDirection.top => false,
       WidgetTooltipDirection.bottom => true,
-      _ => targetCenter.dy <= MediaQuery.of(context).size.height / 2,
+      _ => widget.autoFlip
+          ? targetCenter.dy <= screenHeight / 2
+          : true, // default: tooltip below target (isTop means target is on top side)
     };
 
     // Anchors

--- a/test/widget_tooltip_test.dart
+++ b/test/widget_tooltip_test.dart
@@ -695,6 +695,146 @@ void main() {
       });
     });
 
+    group('autoFlip behavior', () {
+      testWidgets(
+          'autoFlip false without direction defaults to showing below',
+          (WidgetTester tester) async {
+        final controller = TooltipController();
+
+        // Place target at bottom of screen — without autoFlip,
+        // tooltip should still appear below (default), not flip to top.
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Align(
+                alignment: Alignment.bottomCenter,
+                child: Padding(
+                  padding: const EdgeInsets.only(bottom: 100),
+                  child: WidgetTooltip(
+                    message: const Text('Tooltip message'),
+                    controller: controller,
+                    autoFlip: false,
+                    animation: WidgetTooltipAnimation.none,
+                    child: const Text('Target'),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        controller.show();
+        await tester.pumpAndSettle();
+
+        // Tooltip should be visible (rendered below target as default)
+        expect(find.text('Tooltip message'), findsOneWidget);
+
+        // Verify the tooltip is positioned below the target
+        final targetBox =
+            tester.renderObject(find.text('Target')) as RenderBox;
+        final targetPos = targetBox.localToGlobal(Offset.zero);
+
+        final tooltipBox =
+            tester.renderObject(find.text('Tooltip message')) as RenderBox;
+        final tooltipPos = tooltipBox.localToGlobal(Offset.zero);
+
+        // Tooltip top should be at or below the target bottom
+        expect(tooltipPos.dy, greaterThanOrEqualTo(targetPos.dy));
+      });
+
+      testWidgets(
+          'autoFlip false with direction top always shows above regardless of position',
+          (WidgetTester tester) async {
+        final controller = TooltipController();
+
+        // Place target near top of screen — with autoFlip: false + direction: top,
+        // it should still show above, not flip.
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Align(
+                alignment: Alignment.topCenter,
+                child: Padding(
+                  padding: const EdgeInsets.only(top: 80),
+                  child: WidgetTooltip(
+                    message: const Text('Tooltip message'),
+                    controller: controller,
+                    autoFlip: false,
+                    direction: WidgetTooltipDirection.top,
+                    animation: WidgetTooltipAnimation.none,
+                    child: const Text('Target'),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        controller.show();
+        await tester.pumpAndSettle();
+
+        expect(find.text('Tooltip message'), findsOneWidget);
+
+        // Verify the tooltip is positioned above the target
+        final targetBox =
+            tester.renderObject(find.text('Target')) as RenderBox;
+        final targetPos = targetBox.localToGlobal(Offset.zero);
+
+        final tooltipBox =
+            tester.renderObject(find.text('Tooltip message')) as RenderBox;
+        final tooltipPos = tooltipBox.localToGlobal(Offset.zero);
+
+        // Tooltip bottom should be at or above the target top
+        expect(tooltipPos.dy + tooltipBox.size.height,
+            lessThanOrEqualTo(targetPos.dy + 20)); // allow some padding
+      });
+
+      testWidgets(
+          'autoFlip true (default) auto-positions based on screen center',
+          (WidgetTester tester) async {
+        final controller = TooltipController();
+
+        // Place target at top of screen — with autoFlip: true (default),
+        // it should auto-position below the target since it's in the top half.
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Align(
+                alignment: Alignment.topCenter,
+                child: Padding(
+                  padding: const EdgeInsets.only(top: 50),
+                  child: WidgetTooltip(
+                    message: const Text('Tooltip message'),
+                    controller: controller,
+                    autoFlip: true,
+                    animation: WidgetTooltipAnimation.none,
+                    child: const Text('Target'),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        controller.show();
+        await tester.pumpAndSettle();
+
+        expect(find.text('Tooltip message'), findsOneWidget);
+
+        // Verify the tooltip is positioned below the target (auto-flipped to bottom)
+        final targetBox =
+            tester.renderObject(find.text('Target')) as RenderBox;
+        final targetPos = targetBox.localToGlobal(Offset.zero);
+
+        final tooltipBox =
+            tester.renderObject(find.text('Tooltip message')) as RenderBox;
+        final tooltipPos = tooltipBox.localToGlobal(Offset.zero);
+
+        // Tooltip should be below the target
+        expect(tooltipPos.dy, greaterThanOrEqualTo(targetPos.dy));
+      });
+    });
+
     group('Direction with autoFlip (Issue #7)', () {
       testWidgets(
           'direction top is respected with autoFlip true in top half of screen',


### PR DESCRIPTION
## Bug

The `autoFlip` property was declared as a parameter on `WidgetTooltip` but never actually referenced in the `_calculateLayout()` method. This meant that setting `autoFlip: false` had no effect — the tooltip would still auto-position based on screen center.

## Fix

Updated the direction flag logic in `_calculateLayout()` to respect `autoFlip`:

- **`autoFlip: true` (default):** Auto-position based on screen center (existing behavior, unchanged)
- **`autoFlip: false` + `direction` set:** Use the explicit direction as-is
- **`autoFlip: false` + no direction:** Default to bottom (vertical axis) / right (horizontal axis) without smart screen-center-based positioning

## Tests

Added 3 new tests covering:
1. `autoFlip: false` without direction defaults to showing below the target
2. `autoFlip: false` with `direction: top` always shows above regardless of target screen position
3. `autoFlip: true` still auto-positions based on screen center

All 36 tests pass (33 existing + 3 new).