### PR TITLE
chore: remove unused kMinTooltipWidth constant

### DIFF
--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -1,2 +1,0 @@
-/// Minimum width for the tooltip to ensure readability.
-const double kMinTooltipWidth = 100.0;


### PR DESCRIPTION
Remove the unused `kMinTooltipWidth` constant from `lib/src/constants.dart`. It was the only content in the file and was never referenced anywhere in the codebase, so the entire file is deleted. All tests pass.