### PR TITLE
chore: fix SDK and dependency constraints

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://github.com/hongmono
 
 environment:
   sdk: '>=3.2.5 <4.0.0'
-  flutter: ">=1.17.0"
+  flutter: ">=3.10.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Problem

The `pubspec.yaml` had `flutter: ">=1.17.0"` but the codebase uses Dart 3.0+ features:
- **Switch expressions** (Dart 3.0)
- **Records** (Dart 3.0)  
- **super.key** (Dart 2.17)

This meant pub would allow installing on Flutter versions that can't actually compile the code.

## Changes

- Updated `flutter` constraint from `>=1.17.0` to `>=3.10.0` (Flutter 3.10 is the first version shipping Dart 3.0)

## Tests

All 33 tests pass.